### PR TITLE
Fix Dockerbuild Github Action

### DIFF
--- a/.github/workflows/dockerbuild.yaml
+++ b/.github/workflows/dockerbuild.yaml
@@ -2,7 +2,11 @@ name: dockerbuild
 
 on:
   push:
-    branches: [main] 
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'  # Ignore changes to markdown files
+
 jobs:
   main:
     runs-on: ubuntu-latest


### PR DESCRIPTION
To prevent the GitHub Action from running when markdown files are pushed, we could use path filters in the workflow. We could use the paths-ignore option to specify the paths that should be ignored.